### PR TITLE
Fix symbol to string conversion error in react helmet

### DIFF
--- a/src/components/IdeaDetail.js
+++ b/src/components/IdeaDetail.js
@@ -46,8 +46,8 @@ const IdeaDetail = () => {
   return (
     <div className='research-detail-container'>
       <SEO
-        title={paper.title}
-        description={paper.abstract || paper.title}
+        title={String(paper.title || '')}
+        description={String(paper.abstract || paper.title || '')}
         url={`/ideas/${encodeURIComponent(decoded)}`}
         type='article'
       />

--- a/src/components/PostDetail.js
+++ b/src/components/PostDetail.js
@@ -94,7 +94,7 @@ const PostDetail = () => {
   const wordCount = getWordCount(post.content);
   const formattedDate = formatDate(post.date);
   const cleanedContent = cleanHtmlContent(post.content);
-  const excerpt = cleanedContent.replace(/<[^>]*>/g, '').slice(0, 200);
+  const excerpt = String(cleanedContent || '').replace(/<[^>]*>/g, '').slice(0, 200);
 
   const onCopyLink = async () => {
     try {
@@ -131,11 +131,11 @@ const PostDetail = () => {
   return (
     <div className='post-detail-container'>
       <SEO
-        title={post.title}
-        description={excerpt}
+        title={String(post.title || '')}
+        description={String(excerpt || '')}
         url={`/posts/${encodeURIComponent(decoded)}`}
         type='article'
-        publishedTime={post.date}
+        publishedTime={String(post.date || '')}
       />
       <div className='reading-progress'>
         <div className='reading-progress-bar' style={{ width: `${progress}%` }}></div>

--- a/src/components/ProjectDetail.js
+++ b/src/components/ProjectDetail.js
@@ -46,8 +46,8 @@ const ProjectDetail = () => {
   return (
     <div className='project-detail-container'>
       <SEO
-        title={project.title || 'Project'}
-        description={project.abstract || project.title || 'Project details'}
+        title={String(project.title || 'Project')}
+        description={String(project.abstract || project.title || 'Project details')}
         url={`/projects/${encodeURIComponent(decoded)}`}
         type='article'
         image={project.image || undefined}

--- a/src/utils/contentUtils.js
+++ b/src/utils/contentUtils.js
@@ -9,8 +9,8 @@
 export const calculateReadingTime = (content, wordsPerMinute = 200) => {
   if (!content) return 1;
   
-  // Remove HTML tags and get text content
-  const textContent = content.replace(/<[^>]*>/g, '').trim();
+  // Ensure content is a string and remove HTML tags
+  const textContent = String(content).replace(/<[^>]*>/g, '').trim();
   
   // Count words (split by whitespace and filter out empty strings)
   const wordCount = textContent.split(/\s+/).filter(word => word.length > 0).length;
@@ -31,8 +31,8 @@ export const calculateReadingTime = (content, wordsPerMinute = 200) => {
 export const extractExcerpt = (content, maxLength = 150) => {
   if (!content) return '';
   
-  // Remove HTML tags and get text content
-  const textContent = content.replace(/<[^>]*>/g, '').trim();
+  // Ensure content is a string and remove HTML tags
+  const textContent = String(content).replace(/<[^>]*>/g, '').trim();
   
   if (textContent.length <= maxLength) {
     return textContent;
@@ -77,7 +77,7 @@ export const formatDate = (dateString) => {
 export const getWordCount = (content) => {
   if (!content) return 0;
   
-  const textContent = content.replace(/<[^>]*>/g, '').trim();
+  const textContent = String(content).replace(/<[^>]*>/g, '').trim();
   return textContent.split(/\s+/).filter(word => word.length > 0).length;
 };
 
@@ -89,6 +89,9 @@ export const getWordCount = (content) => {
 export const cleanHtmlContent = (content) => {
   if (!content) return '';
   
+  // Ensure content is a string
+  const stringContent = String(content);
+  
   // Remove any potentially dangerous scripts
-  return content.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
+  return stringContent.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
 }; 


### PR DESCRIPTION
Add explicit `String()` conversions to SEO component props and content utility functions to prevent `TypeError: Cannot convert a Symbol value to a string` in `react-helmet`.

The `react-helmet` library expects string values for its meta tag attributes (e.g., `title`, `description`). When `Symbol` or `undefined` values were inadvertently passed, it resulted in a runtime error. Explicitly converting these values to strings ensures compatibility and robust error handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-45ed809b-2511-4b95-8ca8-c9f7db425f56">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-45ed809b-2511-4b95-8ca8-c9f7db425f56">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

