### PR TITLE
Fix symbol to string conversion error in Helmet

### DIFF
--- a/src/components/common/seo/SEO.js
+++ b/src/components/common/seo/SEO.js
@@ -41,18 +41,20 @@ const SEO = ({
       <meta property="og:image:alt" content={description || ''} />
       <meta property="og:locale" content="en_US" />
       
-      {/* Article specific meta tags */}
-      {type === 'article' && (
-        <>
-          <meta property="article:author" content={author} />
-          <meta property="article:section" content={section} />
-          {publishedTime && <meta property="article:published_time" content={publishedTime} />}
-          {modifiedTime && <meta property="article:modified_time" content={modifiedTime} />}
-          {tags.map((tag, index) => (
-            <meta key={index} property="article:tag" content={tag} />
-          ))}
-        </>
+      {/* Article specific meta tags (avoid React Fragments inside Helmet) */}
+      {type === 'article' && <meta property="article:author" content={author} />}
+      {type === 'article' && <meta property="article:section" content={section || ''} />}
+      {type === 'article' && publishedTime && (
+        <meta property="article:published_time" content={publishedTime} />
       )}
+      {type === 'article' && modifiedTime && (
+        <meta property="article:modified_time" content={modifiedTime} />
+      )}
+      {type === 'article' &&
+        Array.isArray(tags) &&
+        tags.map((tag, index) => (
+          <meta key={`article-tag-${index}`} property="article:tag" content={tag} />
+        ))}
       
       {/* Twitter Meta Tags */}
       <meta name="twitter:card" content="summary_large_image" />


### PR DESCRIPTION
Remove React Fragment from Helmet children to fix Symbol-to-string conversion error.

The `react-helmet` library does not support React Fragments as direct children, leading to a `TypeError: Cannot convert a Symbol value to a string` when attempting to process the Fragment's Symbol type. This change renders conditional `<meta>` tags directly within `<Helmet>` instead.

---
<a href="https://cursor.com/background-agent?bcId=bc-a080bc58-2651-478c-9401-43e2fea6ef63">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a080bc58-2651-478c-9401-43e2fea6ef63">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

