### PR TITLE
Generate dynamic open graph images for website content

### DIFF
--- a/src/utils/openGraphImages.js
+++ b/src/utils/openGraphImages.js
@@ -151,7 +151,7 @@ export const getDefaultOGImage = () => {
  * @param {Object} content - The content object
  * @returns {string} The URL to the appropriate Open Graph image
  */
-export const getContentOGImage = (contentType, content) => {
+export const getContentOGImage = (content, contentType) => {
   switch (contentType) {
     case 'post':
       return getPostOGImage(content);


### PR DESCRIPTION
Fix parameter order in `getContentOGImage` to enable correct dynamic Open Graph image selection.

The previous parameter order in `getContentOGImage` was incorrect, leading to the wrong Open Graph image being chosen for content pages. This change aligns the function signature with its intended usage, allowing dynamic Open Graph images to be correctly generated based on content type and specific content.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a140b85-6da8-4846-9812-c5d79d89ff89">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6a140b85-6da8-4846-9812-c5d79d89ff89">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

